### PR TITLE
Attempt to fix & refactor redirects

### DIFF
--- a/server/lib/redirects.js
+++ b/server/lib/redirects.js
@@ -1,97 +1,48 @@
-// const HTTP_REDIRECT_TEMPORARY = 301;
-// const HTTP_REDIRECT_PERMANENT = 302;
-// const urlsToRedirectToEn = ["/meteor", "/swift", "/interaction-engineering"];
-// const urlsToRedirectToNl = ["/games"];
-// const demoUrls = ["/demos/colorblindnesssimulator", "/demos/contrastcheck"];
-
 // Use Picker middleware to handle server-side routes
 // per https://github.com/meteorhacks/picker/issues/22
 
-// .NL ==> .COM
-// Picker.middleware((req, res, next) => {
-//   if (req.headers.host === "q42.nl"){
-//     if (urlsToRedirectToEn.indexOf(req.url) !== -1){
-//       console.log(`Redirect NL to EN: ${req.url}`);
-//       res.writeHead(HTTP_REDIRECT_PERMANENT, {
-//         Location: `http://q42.com${req.url}`
-//       });
-//       res.end();
-//     }
-//   } else {
-//     next();
-//   }
-// });
+redirect(["/meteor", "/swift", "/interaction-engineering"],
+  "q42.nl", "q42.com");
+redirect(["/games"], "q42.com", "q42.nl");
 
-// .COM ==> .NL
-// Picker.middleware((req, res, next) => {
-//   if (req.headers.host === "q42.com"){
-//     if (urlsToRedirectToEn.indexOf(req.url) !== -1){
-//       console.log(`Redirect EN to NL: ${req.url}`);
-//       res.writeHead(HTTP_REDIRECT_PERMANENT, {
-//         Location: `http://q42.nl${req.url}`
-//       });
-//       res.end();
-//     }
-//   } else {
-//     next();
-//   }
-// });
-//
-// Picker.middleware((req, res, next) => {
-//   if (_.contains(["/accessibility", "/a11y"], req.url)){
-//     res.writeHead(HTTP_REDIRECT_PERMANENT, {
-//       Location: "http://q42.com/interaction-engineering"
-//     });
-//     res.end();
-//
-//   } else if (req.url === "/adventures"){
-//     res.writeHead(HTTP_REDIRECT_TEMPORARY, {
-//       Location: "http://adventures.handcraft.com"
-//     });
-//     res.end();
-//
-//   // SEE extension
-//   } else if (_.contains(demoUrls, req.url)){
-//     res.writeHead(HTTP_REDIRECT_PERMANENT,{
-//       Location: `https://chrome.google.com/webstore/
-//                 detail/see/dkihcccbkkakkbpikjmpnbamkgbjfdcn`
-//     });
-//     res.end();
-//
-//   } else {
-//     next();
-//   }
-// });
+redirect(["/accessibility", "/a11y"], null,
+  "http://q42.com/interaction-engineering");
+redirect(["/adventures"], null, "http://adventures.handcraft.com");
 
-// XXX: make this easier
-// Picker.middleware((req, res, next) => {
-//   const isDotCom = req.headers.host === "q42.com";
-//   if (isDotCom && _.contains("products", req.url)) {
-//     res.writeHead(HTTP_REDIRECT_PERMANENT, {
-//       Location: "http://q42.com/projects"
-//     });
-//     res.end();
-//   }
-//   else if (!isDotCom && _.contains("producten", req.url)) {
-//     res.writehead(HTTP_REDIRECT_PERMANENT, {
-//       Location: "http://q42.nl/projecten"
-//     });
-//     res.end();
-//   } else {
-//     next();
-//   }
-// });
+const demoUrls = ["/demos/colorblindnesssimulator", "/demos/contrastcheck"];
+const seeChromeWebStore = "https://chrome.google.com/webstore/detail/see/" +
+                          "dkihcccbkkakkbpikjmpnbamkgbjfdcn";
+redirect(demoUrls, null, seeChromeWebStore);
 
-// Picker.middleware((req, res, next) => {
-//   const host = req.headers.host;
-//   const fullUrl = `http://${host}${req.url}`;
-//   if (host.indexOf("www") === 0){
-//     console.log(`Route: removeWWW (${req.url})`);
-//     res.writeHead(HTTP_REDIRECT_PERMANENT, {
-//       Location: fullUrl.replace("www.", "")
-//     });
-//     res.end();
-//   } else {
-//     next();
-//   }
-// });
+redirect(["products"], "q42.com", "http://q42.com/projects");
+redirect(["producten"], "q42.nl", "http://q42.nl/projecten");
+
+function redirect(urls, from, to) {
+  const HTTP_REDIRECT_PERMANENT = 302;
+  Picker.middleware((req, res, next) => {
+    const check = (from) => from ? req.headers.host === from : true;
+    if (check() && urls.indexOf(req.url) !== -1) {
+      console.log(`Redirect ${from} to ${to}: ${req.url}`);
+      res.writeHead(HTTP_REDIRECT_PERMANENT, {
+        Location: `http://${to}${req.url}`
+      });
+      res.end();
+    } else {
+      next();
+    }
+  });
+}
+
+Picker.middleware((req, res, next) => {
+  const host = req.headers.host;
+  const fullUrl = `http://${host}${req.url}`;
+  if (host.indexOf("www") === 0){
+    console.log(`Route: removeWWW (${req.url})`);
+    res.writeHead(HTTP_REDIRECT_PERMANENT, {
+      Location: fullUrl.replace("www.", "")
+    });
+    res.end();
+  } else {
+    next();
+  }
+});

--- a/server/lib/redirects.js
+++ b/server/lib/redirects.js
@@ -18,7 +18,6 @@ redirect(["/products"], null, "http://q42.com/projects");
 redirect(["/producten"], null, "http://q42.nl/projecten");
 
 function redirect(urls, from, to) {
-  console.log("redirecting!");
   const HTTP_REDIRECT_PERMANENT = 302;
   Picker.middleware((req, res, next) => {
     const check = (from) => req.headers.host === from;

--- a/server/lib/redirects.js
+++ b/server/lib/redirects.js
@@ -14,8 +14,8 @@ const seeChromeWebStore = "https://chrome.google.com/webstore/detail/see/" +
                           "dkihcccbkkakkbpikjmpnbamkgbjfdcn";
 redirect(demoUrls, null, seeChromeWebStore);
 
-redirect(["products"], "q42.com", "http://q42.com/projects");
-redirect(["producten"], "q42.nl", "http://q42.nl/projecten");
+redirect(["/products"], null, "http://q42.com/projects");
+redirect(["/producten"], null, "http://q42.nl/projecten");
 
 function redirect(urls, from, to) {
   console.log("redirecting!");

--- a/server/lib/redirects.js
+++ b/server/lib/redirects.js
@@ -19,10 +19,11 @@ redirect(demoUrls, null, seeChromeWebStore);
 redirect(["/products"], null, "http://q42.com/projects");
 redirect(["/producten"], null, "http://q42.nl/projecten");
 
+// XXX: redesign magic 'from' argument
 function redirect(urls, from, to) {
   Picker.middleware((req, res, next) => {
-    const check = (from) => from ? req.headers.host === from : true;
-    if (check(from) && urls.indexOf(req.url) !== -1) {
+    const match = () => from ? req.headers.host === from : true;
+    if (match() && urls.indexOf(req.url) !== -1) {
       const destination = from ? `http://${to}${req.url}` : to;
       console.log(`Redirect ${from} to ${destination}`);
       res.writeHead(HTTP_REDIRECT_PERMANENT, {

--- a/server/lib/redirects.js
+++ b/server/lib/redirects.js
@@ -20,17 +20,12 @@ redirect(["/producten"], null, "http://q42.nl/projecten");
 function redirect(urls, from, to) {
   const HTTP_REDIRECT_PERMANENT = 302;
   Picker.middleware((req, res, next) => {
-    const check = (from) => req.headers.host === from;
-    if (!from && urls.indexOf(req.url) !== -1) {
-      console.log(`Redirect ${from} to ${to}`);
+    const check = (from) => from ? req.headers.host === from : true;
+    if (check(from) && urls.indexOf(req.url) !== -1) {
+      const destination = from ? `http://${to}${req.url}` : to;
+      console.log(`Redirect ${from} to ${destination}`);
       res.writeHead(HTTP_REDIRECT_PERMANENT, {
-        Location: to
-      });
-      res.end();
-    } else if (check(from) && urls.indexOf(req.url) !== -1) {
-      console.log(`Redirect ${from} to ${to}: ${req.url}`);
-      res.writeHead(HTTP_REDIRECT_PERMANENT, {
-        Location: `http://${to}${req.url}`
+        Location: destination
       });
       res.end();
     } else {

--- a/server/lib/redirects.js
+++ b/server/lib/redirects.js
@@ -21,7 +21,7 @@ function redirect(urls, from, to) {
   const HTTP_REDIRECT_PERMANENT = 302;
   Picker.middleware((req, res, next) => {
     const check = (from) => from ? req.headers.host === from : true;
-    if (check() && urls.indexOf(req.url) !== -1) {
+    if (check(from) && urls.indexOf(req.url) !== -1) {
       console.log(`Redirect ${from} to ${to}: ${req.url}`);
       res.writeHead(HTTP_REDIRECT_PERMANENT, {
         Location: `http://${to}${req.url}`

--- a/server/lib/redirects.js
+++ b/server/lib/redirects.js
@@ -18,10 +18,17 @@ redirect(["products"], "q42.com", "http://q42.com/projects");
 redirect(["producten"], "q42.nl", "http://q42.nl/projecten");
 
 function redirect(urls, from, to) {
+  console.log("redirecting!");
   const HTTP_REDIRECT_PERMANENT = 302;
   Picker.middleware((req, res, next) => {
-    const check = (from) => from ? req.headers.host === from : true;
-    if (check(from) && urls.indexOf(req.url) !== -1) {
+    const check = (from) => req.headers.host === from;
+    if (!from && urls.indexOf(req.url) !== -1) {
+      console.log(`Redirect ${from} to ${to}`);
+      res.writeHead(HTTP_REDIRECT_PERMANENT, {
+        Location: to
+      });
+      res.end();
+    } else if (check(from) && urls.indexOf(req.url) !== -1) {
       console.log(`Redirect ${from} to ${to}: ${req.url}`);
       res.writeHead(HTTP_REDIRECT_PERMANENT, {
         Location: `http://${to}${req.url}`

--- a/server/lib/redirects.js
+++ b/server/lib/redirects.js
@@ -1,6 +1,8 @@
 // Use Picker middleware to handle server-side routes
 // per https://github.com/meteorhacks/picker/issues/22
 
+const HTTP_REDIRECT_PERMANENT = 302;
+
 redirect(["/meteor", "/swift", "/interaction-engineering"],
   "q42.nl", "q42.com");
 redirect(["/games"], "q42.com", "q42.nl");
@@ -18,7 +20,6 @@ redirect(["/products"], null, "http://q42.com/projects");
 redirect(["/producten"], null, "http://q42.nl/projecten");
 
 function redirect(urls, from, to) {
-  const HTTP_REDIRECT_PERMANENT = 302;
   Picker.middleware((req, res, next) => {
     const check = (from) => from ? req.headers.host === from : true;
     if (check(from) && urls.indexOf(req.url) !== -1) {


### PR DESCRIPTION
This attempts to fix the broken redirects code that was causing the site to never load. Most redirects behave the same so they've been collapsed into one function, making the code easier to read and reuse. The single exception to this is the redirect that force-strips "www." from the url.

This needs testing against q42.nl and q42.com to ensure we don't break anything. We also need to test that the user arrives at the correct location and the correct header is used.