### PR TITLE
shows 'blog' instead of 'en' at the top of the English version of the blog

### DIFF
--- a/to-become-packages/blog/client/blog.js
+++ b/to-become-packages/blog/client/blog.js
@@ -26,7 +26,10 @@ $Template({
 });
 
 Template.blog.helpers({
-  tag: () => FlowRouter.getParam('tag')
+  tag: () => {
+    const tag = FlowRouter.getParam('tag');
+    return tag === "en" ? "blog" : tag;
+  }
 });
 
 Template.blogpost.helpers({


### PR DESCRIPTION
The English blog posts are tagged 'en', and the template shows the current tag's name on the top of the blog. So I hard-coded the helper to return 'blog' instead if the tag is 'en'. Not sure if there's a more elegant way to do this without changing the way the English blog works.

trello issue: https://trello.com/c/6iA8xA2X