### PR TITLE
Haal tekst over koffie in Amsterdam weg.

### DIFF
--- a/views/nl/page/Over-q42.html
+++ b/views/nl/page/Over-q42.html
@@ -106,9 +106,6 @@
           <p>Vandaag hebben wij al</p>
           {{> numCupsOfCoffee}}
           <p>koppen koffie op.</p>
-          <p><small>
-            (in ons kantoor in Amsterdam)
-          </small></p>
         </div>
       </div>
       <div class="block-small">


### PR DESCRIPTION
De koffie data komt nu uit Den Haag en Amsterdam.