### PR TITLE
Fixes code overflow bug in Firefox

### DIFF
--- a/styles/blog.styl
+++ b/styles/blog.styl
@@ -59,6 +59,7 @@
   @media (min-width 480px)
     padding 0
     width 100%
+    min-width 0
 
 .blog-post
   h2


### PR DESCRIPTION
This is the issue and fix: http://stackoverflow.com/questions/28896807/pre-code-element-with-horizontal-scrollbar-breaks-the-flex-layout-on-firefox

It happens on https://www.q42.nl/blog/post/133591843068/imagepreview-library

![screen shot 2016-06-22 at 12 52 06](https://cloud.githubusercontent.com/assets/75655/16264154/2a0a4ee4-3878-11e6-9fde-ed41d739ca4b.png)
