### PR TITLE
Removed 1password from the nl/en toolbox pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create a `config/dev/settings.json` file
 ```
 {
 	"public": {
-		"siteVersion": "nl", // or "en" to develop the .com site
+		"siteVersion": "nl" // or "en" to develop the .com site
 	},
 	"private": {
 		"MONGO_URL": "...",

--- a/views/en/page/toolbox.html
+++ b/views/en/page/toolbox.html
@@ -121,23 +121,6 @@
         </div>
         <div class="block-small">
           <div class="visual caption">
-            <img src="{{assetsUrl}}/images/1password.jpg" alt="" />
-            <p>Something we gladly pay for!</p>
-          </div>
-          <div class="body">
-            <h2>1Password</h2>
-            <h3>Safely dealing with connection strings and such</h3>
-            <p>For years we wondered how we were supposed to securely store and share secrets. It seemed like we'd get one or the other, but not both.
-              Until 1Password for Teams was released. Now we can do both. And it works pretty well!</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section>
-      <div class="block-large">
-        <div class="block-small">
-          <div class="visual caption">
             <img src="{{assetsUrl}}/images/trello.png" alt="" />
             <p>:taco:</p>
           </div>
@@ -148,6 +131,11 @@
             <p>By the way, did you know we built a <a href="https://chrome.google.com/webstore/detail/scrum-for-trello/jdbcdblgjdpmfninkoogcfpnkjmndgje?utm_source=chrome-ntp-icon">Scrum extension for Trello</a>? Super useful.</p>
           </div>
         </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="block-large">
         <div class="block-small">
           <div class="visual caption">
             <img src="{{assetsUrl}}/images/dropbox.jpg" alt="" />

--- a/views/nl/page/Gereedschapskist.html
+++ b/views/nl/page/Gereedschapskist.html
@@ -121,23 +121,6 @@
         </div>
         <div class="block-small">
           <div class="visual caption">
-            <img src="{{assetsUrl}}/images/1password.jpg" alt="" />
-            <p>Daar betalen we graag voor!</p>
-          </div>
-          <div class="body">
-            <h2>1Password</h2>
-            <h3>Veilig omgaan met connection strings enzo</h3>
-            <p>Jarenlang vroegen we ons af hoe we nou precies veilig geheimen konden opslaan én delen. Het leek wel het één of het andere.
-            Totdat 1Password for Teams uitkwam. Nu kan het allebei. En dat werkt behoorlijk goed!</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section>
-      <div class="block-large">
-        <div class="block-small">
-          <div class="visual caption">
             <img src="{{assetsUrl}}/images/trello.png" alt="" />
             <p>:taco:</p>
           </div>
@@ -148,6 +131,11 @@
             <p>Wist je trouwens dat we een <a href="https://chrome.google.com/webstore/detail/scrum-for-trello/jdbcdblgjdpmfninkoogcfpnkjmndgje?utm_source=chrome-ntp-icon">Scrum uitbreiding voor Trello</a> hebben gemaakt? Superhandig.</p>
           </div>
         </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="block-large">
         <div class="block-small">
           <div class="visual caption">
             <img src="{{assetsUrl}}/images/dropbox.jpg" alt="" />


### PR DESCRIPTION
See discussion https://q42.slack.com/archives/C028BDSCH/p1496817882434512

1password.jpg still needs to be removed from the assets bucket.
